### PR TITLE
Fix broken specs

### DIFF
--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -29,7 +29,7 @@
 
 
     <div class="input-field col s12">
-      <%= f.input :description, as: :text, input_html: {id: "textarea1", class: "materialize-textarea", "data-length": 250} %>
+      <%= f.input :description, as: :text, input_html: { class: "materialize-textarea", "data-length": 250} %>
     </div>
 
     <div class="input-field col s3">
@@ -69,7 +69,7 @@
 
     <%= f.simple_fields_for :rule do |r| %>
     <div class="input-field col s12">
-      <%= r.input :description, as: :text, input_html: {id: "textarea2", class: "materialize-textarea", "data-length": 250} %>
+      <%= r.input :description, as: :text, input_html: {class: "materialize-textarea", "data-length": 250} %>
     </div>
 
    <% end %>

--- a/spec/factories/properties_factory.rb
+++ b/spec/factories/properties_factory.rb
@@ -17,8 +17,4 @@ FactoryGirl.define do
   trait :invalid do
     title { nil }
   end
-
-  trait :invalid do
-    title { nil }
-  end
 end

--- a/spec/features/properties/creating_properties_spec.rb
+++ b/spec/features/properties/creating_properties_spec.rb
@@ -1,76 +1,36 @@
 require 'rails_helper'
-require 'support/form'
 
 RSpec.feature "The user can register a new properties" do
-  
-  let(:archetype) { create_list(:archetype, 3) }
-  let(:property) { FactoryGirl.create(:property) }
-  let(:rule) { FactoryGirl.create(:rule) }
-  let(:form) { Form.new }
+  let!(:archetype) { create_list(:archetype, 3) }
+  let(:property) { attributes_for(:property) }
+  let(:rule) { create(:rule) }
 
-
-
-   before do
-     visit "/"
-     within '#main-menu-nav' do
-       click_link I18n.t('.menu.register_fraternity')
-     end
-   end
+  before do
+    visit "/properties/new"
+  end
 
   scenario "with valid attributes" do
+    fill_in('property_title', with: property[:title])
+    fill_in('property_description', with: property[:description])
+    fill_in('property_accommodates', with: property[:accommodates])
+    fill_in('property_bathrooms', with: property[:bathrooms])
+    fill_in('property_number_of_rooms', with: property[:number_of_rooms])
+    fill_in('property_price', with: property[:price])
 
-    form.input 'property', 'title', property[:title]
-
-    form.select_list '.property_archetype', 'property', 'archetype'
-
-    form.input 'property', 'accommodates', property[:accommodates]
-    form.input 'property', 'bathrooms', property[:bathrooms]
-    form.input 'property', 'number_of_rooms', property[:number_of_rooms]
-
-    form.checkbox 'property','furnished'
-    form.checkbox 'property','single_room'
-    form.uncheckbox 'property','share_room'
-
-    form.input 'property', 'price', property[:price]
-    form.input 'property', 'description', property[:description]
-    form.input 'property', 'rule', property[:description]
-
-
-
-    form.checkbox 'property','kitchen'
-    form.checkbox 'property','air_conditioning'
-    form.checkbox 'property','washing_machine'
-    form.checkbox 'property','dryer'
-    form.checkbox 'property','cabo_tv'
-    form.checkbox 'property','pet'
-    form.checkbox 'property','smoke'
-    form.checkbox 'property','accessibility'
-    form.checkbox 'property','elevator'
-    form.checkbox 'property','concierge'
-    form.checkbox 'property','pool'
-    form.checkbox 'property','service_area'
-    form.checkbox 'property','gym'
-    form.checkbox 'property','electric_iron'
-    form.checkbox 'property','notebook_space'
-    form.checkbox 'property','private_entrance'
-
-    form.submit
-
-    binding.pry
+    click_button(I18n.t('properties.index.new_property'))
 
     expect(page).to have_css(".card-content", text: I18n.t('.controllers.property.create.flash.notice'))
   end
 
   scenario "when providing invalid attributes" do
+    click_button(I18n.t('properties.index.new_property'))
 
-      form.submit
-
-      within '#error_explanation' do
-        expect(page).to have_content "#{I18n.t('.activerecord.attributes.property.title')} #{I18n.t('.errors.messages.blank')}"
-        expect(page).to have_content "#{I18n.t('.activerecord.attributes.property.accommodates')} #{I18n.t('.errors.messages.blank')}"
-        expect(page).to have_content "#{I18n.t('.activerecord.attributes.property.bathrooms')} #{I18n.t('.errors.messages.blank')}"
-        expect(page).to have_content "#{I18n.t('.activerecord.attributes.property.price')} #{I18n.t('.errors.messages.blank')}"
-        expect(page).to have_content "#{I18n.t('.activerecord.attributes.property.description')} #{I18n.t('.errors.messages.blank')}"
-      end
+    within '#error_explanation' do
+      expect(page).to have_content "#{I18n.t('.activerecord.attributes.property.title')} #{I18n.t('.errors.messages.blank')}"
+      expect(page).to have_content "#{I18n.t('.activerecord.attributes.property.accommodates')} #{I18n.t('.errors.messages.blank')}"
+      expect(page).to have_content "#{I18n.t('.activerecord.attributes.property.bathrooms')} #{I18n.t('.errors.messages.blank')}"
+      expect(page).to have_content "#{I18n.t('.activerecord.attributes.property.price')} #{I18n.t('.errors.messages.blank')}"
+      expect(page).to have_content "#{I18n.t('.activerecord.attributes.property.description')} #{I18n.t('.errors.messages.blank')}"
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,11 +52,8 @@ RSpec.configure do |config|
   config.after(:each) do
     Capybara.reset_sessions!
     Capybara.use_default_driver
-    Capybara.app_host = nil 
+    Capybara.app_host = nil
+  end
+
   config.include FactoryGirl::Syntax::Methods
-
-
-
-
- 
 end


### PR DESCRIPTION
1. Não reescreva a DSL do capybara, não tem sentido nenhum. Essa ideia de support/form para  adicionar mini helpers na DSL tira a clareza do código e abstrai uma parte importante. Em testes vale mais a pena ser claro do que ser DRY.
2. Se o teste só espera uma flash message, não tem sentido preencher o form inteiro. Mas você pode seguir a mesma ideia para preencher todos os campos caso ache necessário.
3. Cuidado com os erros de sintaxe, seu teste nem estava rodando devido a um end faltando no rails helper.
4. Na view do new não faz sentido renomear os ids que o simple form gera.
5. Não se preocupe com o Selenium simplesmente pq vc não precisa utilizá-lo. O driver só é chamado nas views com js: true, que não é necessário o uso nessa situação.
6. Tome cuidado com o material design pois ele transforma um input do tipo select em um input do tipo div.
7. Utilize a gem rubocop ou siga fielmente o style guide da comunidade https://github.com/bbatsov/rails-style-guide. Se sua IDE tiver um linter  ele vai mostrar as infrações diretamente enquanto estiver escrevendo o código. Procure instalar para aprender as boas práticas.